### PR TITLE
Error handling to stop web crashes

### DIFF
--- a/app/models/pourscore.js
+++ b/app/models/pourscore.js
@@ -5,8 +5,8 @@ const path = require("path");
 const fs = require("fs");
 const { GoogleGenAI } = require("@google/genai");
 
-// Initialize Google Generative AI
-const genAI = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+const googleApiKey = process.env.GOOGLE_API_KEY;
+const genAI = googleApiKey ? new GoogleGenAI({ apiKey: googleApiKey }) : null;
 
 // Multer to save files
 const storage = multer.diskStorage({
@@ -32,6 +32,12 @@ router.post("/", upload.single('image'), async (req, res) => {
     // Check if the user actually sent an image
     if (!req.file) {
         return res.status(400).send("No image uploaded.");
+    }
+
+    if (!genAI) {
+        return res
+            .status(500)
+            .send("GOOGLE_API_KEY is not set, so AI pour scoring is unavailable.");
     }
 
     try {

--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -72,4 +72,3 @@ html
           textarea(name="comment" rows="4" required)
 
           button(type="submit") Submit Review
-link(rel="stylesheet" href="/static/css/styles.css")

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", function() {
+    if (typeof particlesJS !== "function") return;
     const heroes = document.querySelectorAll('section.beer-hero, .beer-hero');
     heroes.forEach((hero, index) => {
         const id = 'particles-hero-' + index;

--- a/static/maps.js
+++ b/static/maps.js
@@ -1,8 +1,25 @@
-fetch("/api/pubs")
-  .then(res => res.json())
-  .then(data => {
+async function fetchJson(url, options) {
+  const res = await fetch(url, options);
+  if (res.redirected && res.url.includes("/login")) {
+    window.location.href = res.url;
+    return null;
+  }
+  const contentType = res.headers.get("content-type") || "";
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+  if (!contentType.includes("application/json")) {
+    throw new Error(`Expected JSON from ${url}, got ${contentType || "unknown"}`);
+  }
+  return res.json();
+}
+
+fetchJson("/api/pubs")
+  .then((data) => {
+    if (!data) return;
     initMap(data);
-  });
+  })
+  .catch((err) => console.error("Error loading map pubs:", err));
 
 function initMap(pubs) {
   const map = L.map("map").setView([51.505, -0.09], 13);
@@ -117,7 +134,7 @@ function initMap(pubs) {
     const popupHTML = `
     <div class="beer-popup">
         <div class="popup-header">
-        🍺 ${pub.name}
+        ${pub.name}
         </div>
         <div class="popup-body">
         ${pub.address}, ${pub.postcode}<br><br>

--- a/static/review.js
+++ b/static/review.js
@@ -10,6 +10,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (!modal) return;
 
+  async function fetchJson(url, options) {
+    const res = await fetch(url, options);
+    if (res.redirected && res.url.includes("/login")) {
+      window.location.href = res.url;
+      return null;
+    }
+    const contentType = res.headers.get("content-type") || "";
+    if (!res.ok) {
+      throw new Error(`${res.status} ${res.statusText}`);
+    }
+    if (!contentType.includes("application/json")) {
+      throw new Error(`Expected JSON from ${url}, got ${contentType || "unknown"}`);
+    }
+    return res.json();
+  }
+
   // Open modal
   if (openBtn) {
     openBtn.addEventListener("click", () => {
@@ -26,9 +42,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Load pubs
   function loadPubs() {
-    fetch("/api/pubs")
-      .then(res => res.json())
+    fetchJson("/api/pubs")
       .then(data => {
+        if (!data) return;
         pubSelect.innerHTML = `<option value="">-- Select Pub --</option>`;
         data.forEach(pub => {
           pubSelect.innerHTML += `<option value="${pub.id}">${pub.name}</option>`;
@@ -45,9 +61,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!pubId) return;
 
-    fetch(`/api/pubs/${pubId}/beers`)
-      .then(res => res.json())
+    fetchJson(`/api/pubs/${pubId}/beers`)
       .then(data => {
+        if (!data) return;
         data.forEach(beer => {
           beerSelect.innerHTML += `<option value="${beer.id}">${beer.name}</option>`;
         });
@@ -99,7 +115,15 @@ document.addEventListener("DOMContentLoaded", () => {
         body: JSON.stringify(data)
       });
 
-      const result = await response.json();
+      if (response.redirected && response.url.includes("/login")) {
+        window.location.href = response.url;
+        return;
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      const result = contentType.includes("application/json")
+        ? await response.json()
+        : { success: false, error: "Unexpected server response" };
 
       if (result.success) {
         alert("Thank you! Your review has been submitted.");


### PR DESCRIPTION
Guard against absent GOOGLE_API_KEY in pourscore by only initializing the GenAI client when the env var is set and returning a 500 with a clear message if AI scoring is requested without a key. Add a reusable fetchJson helper in maps.js and review.js to handle redirected logins, validate JSON content-type, and surface fetch errors; update calls to use it and handle null/redirect cases. Add defensive check in bubbles.js to avoid errors when particlesJS isn't available. Remove the beer emoji from map popups and remove a stylesheet link in layout.pug. These changes reduce runtime errors and improve client-side robustness when auth or expected resources are missing.