### PR TITLE
Add CI workflow; improve DB config defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: tapthat-db
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Wait for MySQL
+        run: |
+          for i in {1..10}; do
+            nc -z 127.0.0.1 3306 && echo "MySQL ready" && exit 0
+            echo "Waiting for MySQL..."
+            sleep 3
+          done
+          exit 1
+
+      - name: Run schema
+        run: mysql -h 127.0.0.1 -uroot -proot tapthat-db < schema.sql
+
+      - name: Run basic app check
+        run: node index.js &
+      
+      - name: Health check
+        run: |
+          sleep 5
+          curl -f http://localhost:3000 || exit 1
+
+      - name: Build Docker image
+        run: docker build -t tapthat-app .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_ROOT_HOST: "%"
           MYSQL_DATABASE: tapthat-db
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h localhost -proot"
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -5,11 +5,28 @@ const mysql = require("mysql2");
 const host =
   process.env.DB_HOST ||
   process.env.DB_CONTAINER ||
-  process.env.MYSQL_HOST;
-const port = process.env.DB_PORT || 3306;
-const user = process.env.DB_USER || process.env.MYSQL_USER;
-const password = process.env.DB_PASSWORD || process.env.MYSQL_PASSWORD;
-const database = process.env.DB_NAME || process.env.MYSQL_DATABASE;
+  process.env.MYSQL_HOST ||
+  "127.0.0.1";
+
+const port =
+  process.env.DB_PORT ||
+  process.env.MYSQL_PORT ||
+  3306;
+
+const user =
+  process.env.DB_USER ||
+  process.env.MYSQL_USER ||
+  "root";
+
+const password =
+  process.env.DB_PASSWORD ||
+  process.env.MYSQL_PASSWORD ||
+  "password";
+
+const database =
+  process.env.DB_NAME ||
+  process.env.MYSQL_DATABASE ||
+  "tapthat-db";
 
 const pool = mysql.createPool({
   host,
@@ -18,7 +35,7 @@ const pool = mysql.createPool({
   password,
   database,
   waitForConnections: true,
-  connectionLimit: 2,
+  connectionLimit: 10,
   queueLimit: 0,
 });
 


### PR DESCRIPTION
Add a GitHub Actions CI pipeline and make DB connection config more robust.

Files changed:
- .github/workflows/ci.yml: new CI pipeline that runs on pushes and PRs, starts a MySQL 8.0 service, checks out code, sets up Node 20, installs deps, waits for MySQL, applies schema.sql, runs a basic app health check (curl on localhost:3000), and builds a Docker image.
- app/services/db.js: broadened environment variable fallbacks and added sane defaults (host -> 127.0.0.1, port fallbacks incl. MYSQL_PORT, user default "root", password default "password", database default "tapthat-db"). Also increased pool connectionLimit from 2 to 10 to allow more concurrent DB connections.

These changes add CI coverage and make local/CI DB configuration more fault-tolerant and better suited for concurrent workloads.